### PR TITLE
chore: prevent pytest database test files from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ docker-compose.override.yml
 *.sqlite
 *.sqlite3
 
+# Pytest database test files
+.pytest_db_test*
+
 # --- Misc ---
 *.log
 *.tmp


### PR DESCRIPTION
- Add .pytest_db_test* pattern to .gitignore
- Remove 40+ existing .pytest_db_test* files from repository
- These files are temporary SQLite databases created during pytest execution
- Prevents test artifacts from cluttering the repository

🤖 Generated with [Claude Code](https://claude.ai/code)